### PR TITLE
mount: allow pre-existing /sys

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func main() {
 		log.Printf("failed to mount: %v", err)
 	}
 	// mount -t sysfs -o nodev,nosuid,noexec sys /sys
-	if err := os.Mkdir("/sys", 0555); err != nil {
+	if err := os.MkdirAll("/sys", 0555); err != nil {
 		log.Printf("failed to create /sys: %v", err)
 	} else if err := mount.Mount("sys", "/sys", "sysfs", "nodev,nosuid,noexec"); err != nil {
 		log.Printf("failed to mount: %v", err)


### PR DESCRIPTION
If /sys directory already exists, error is logged, and /sys is not
attempted to be mounted.

Use MkdirAll call to create /sys if missing, and not error out when it
is already present, and still try to mount it.
